### PR TITLE
添加JDK21下载

### DIFF
--- a/client/src/pages/EnvironmentManagerPage.tsx
+++ b/client/src/pages/EnvironmentManagerPage.tsx
@@ -151,6 +151,14 @@ const EnvironmentManagerPage: React.FC = () => {
       windows: 'https://download.java.net/openjdk/jdk17.0.0.1/ri/openjdk-17.0.0.1+2_windows-x64_bin.zip',
       linux: 'https://download.java.net/openjdk/jdk17.0.0.1/ri/openjdk-17.0.0.1+2_linux-x64_bin.tar.gz',
       arm: 'https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_macos-aarch64_bin.tar.gz'
+    },
+    {
+      version: 'Java 21',
+      key: 'java21',
+      description: 'Java 21 (OpenJDK 21)',
+      windows: 'https://download.java.net/openjdk/jdk21/ri/openjdk-21+35_windows-x64_bin.zip',
+      linux: 'https://download.java.net/openjdk/jdk21/ri/openjdk-21+35_linux-x64_bin.tar.gz',
+      arm: 'https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_macos-aarch64_bin.tar.gz'
     }
   ]
 

--- a/server/src/modules/environment/javaManager.ts
+++ b/server/src/modules/environment/javaManager.ts
@@ -84,7 +84,7 @@ export class JavaManager {
     await this.ensureInstallDir()
 
     const platform = os.platform()
-    const javaVersions = ['java8', 'java11', 'java17']
+    const javaVersions = ['java8', 'java11', 'java17', 'java21']
     const environments: JavaEnvironment[] = []
 
     for (const version of javaVersions) {

--- a/server/src/routes/environment.ts
+++ b/server/src/routes/environment.ts
@@ -116,6 +116,11 @@ function getSponsorDownloadUrl(version: string, platform: string, arch?: string)
       windows: 'openjdk-17.0.0.1+2_windows-x64_bin.zip',
       linux: 'openjdk-17.0.0.1+2_linux-x64_bin.tar.gz',
       arm: 'openjdk-17.0.2_macos-aarch64_bin.tar.gz'
+    },
+    java21: {
+      windows: 'openjdk-21+35_windows-x64_bin.zip',
+      linux: 'openjdk-17.0.0.1+2_linux-x64_bin.tar.gz',
+      arm: 'openjdk-21_macos-aarch64_bin.tar.gz'
     }
   }
 


### PR DESCRIPTION
在运行Minecraft 1.21.8 purpur端时遇到JDK版本问题，发现JDK下载没有21，所以加了上去