### PR TITLE
fix: 脱敏 SteamCMD 转义凭据

### DIFF
--- a/server/src/utils/streamingRedactor.ts
+++ b/server/src/utils/streamingRedactor.ts
@@ -8,7 +8,15 @@ export class StreamingRedactor {
   private ended = false
 
   constructor(values: string[] = []) {
-    this.secrets = [...new Set(values.filter(Boolean))]
+    const variants = values
+      .filter(Boolean)
+      .flatMap(secret => [
+        secret,
+        // SteamCMD may echo runscript arguments using console-style escaping.
+        secret.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+      ])
+
+    this.secrets = [...new Set(variants)]
       .sort((left, right) => right.length - left.length)
     this.tailLength = Math.max(0, ...this.secrets.map(secret => secret.length - 1))
   }


### PR DESCRIPTION
## 问题

在验证 Steam 分支部署时发现：SteamCMD runscript 会对密码中的反斜杠和双引号进行 console-style 转义。如果 SteamCMD 回显该命令，仅匹配原始密码的流式脱敏器无法覆盖转义后的文本。

## 修复

- 为每个敏感值同时登记原始形式和 SteamCMD 转义形式。
- 保持最长值优先匹配以及跨输出分块的尾部缓冲逻辑。
- 不改变调用方接口。

## 验证

- Mock SteamCMD 验证原始密码与转义密码均不会出现在输出中。
- 验证转义密码跨两个输出 chunk 时仍被完整脱敏。
- 验证 Steam AppInfo/VDF 分支解析、缓存、并发去重、BuildID 和密码分支标记。
- `cd client && npx tsc --noEmit`
- `cd server && npx tsc --noEmit`
- `npm run build`
- 独立代码审查：APPROVE，无阻塞项。
