### PR TITLE
feat: 构建时自动注入面板版本号

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,27 @@ on:
     types: [published]
 
 jobs:
+  resolve_version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is_stable: ${{ steps.version.outputs.is_stable }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.16.0'
+      - name: Resolve build version
+        id: version
+        run: node scripts/resolve-build-version.js
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+
   build_linux:
+    needs: resolve_version
     if: github.event.inputs.build_linux == 'true' || github.event_name == 'push' || github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
@@ -57,6 +77,8 @@ jobs:
         env:
           CI: true
           NODE_ENV: production
+          APP_VERSION: ${{ needs.resolve_version.outputs.version }}
+          VITE_APP_VERSION: ${{ needs.resolve_version.outputs.version }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -65,6 +87,7 @@ jobs:
           retention-days: 30
 
   build_windows:
+    needs: resolve_version
     if: github.event.inputs.build_windows == 'true' || github.event_name == 'push' || github.event_name == 'release'
     runs-on: windows-latest
     steps:
@@ -88,6 +111,8 @@ jobs:
         env:
           CI: true
           NODE_ENV: production
+          APP_VERSION: ${{ needs.resolve_version.outputs.version }}
+          VITE_APP_VERSION: ${{ needs.resolve_version.outputs.version }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -96,6 +121,7 @@ jobs:
           retention-days: 30
 
   build_docker:
+    needs: resolve_version
     if: github.event.inputs.build_docker == 'true' || github.event_name == 'push' || github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
@@ -127,12 +153,15 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            xiaozhu674/gameservermanager:3.13.0
-            xiaozhu674/gameservermanager:latest
+            xiaozhu674/gameservermanager:${{ needs.resolve_version.outputs.version }}
+            ${{ needs.resolve_version.outputs.is_stable == 'true' && 'xiaozhu674/gameservermanager:latest' || '' }}
+          build-args: |
+            APP_VERSION=${{ needs.resolve_version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   build_docker_arm:
+    needs: resolve_version
     if: github.event.inputs.build_docker_arm == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -164,14 +193,16 @@ jobs:
           platforms: linux/arm64
           push: true
           tags: |
-            xiaozhu674/gameservermanager:3.13.0-arm64-beta
+            xiaozhu674/gameservermanager:${{ needs.resolve_version.outputs.version }}-arm64-beta
+          build-args: |
+            APP_VERSION=${{ needs.resolve_version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   # 创建发布版本（仅在推送标签时触发）
   create_release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build_linux, build_windows]
+    needs: [resolve_version, build_linux, build_windows]
     runs-on: ubuntu-latest
     steps:
       - name: Download Linux artifact
@@ -187,17 +218,17 @@ jobs:
       - name: Create Linux tar.gz
         run: |
           cd linux-build
-          tar -czf ../gsm3-management-panel-linux.tar.gz *
+          tar -czf ../gsm3-management-panel-linux-v${{ needs.resolve_version.outputs.version }}.tar.gz *
       - name: Create Windows zip
         run: |
           cd windows-build
-          zip -r ../gsm3-management-panel-windows.zip *
+          zip -r ../gsm3-management-panel-windows-v${{ needs.resolve_version.outputs.version }}.zip *
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            gsm3-management-panel-linux.tar.gz
-            gsm3-management-panel-windows.zip
+            gsm3-management-panel-linux-v${{ needs.resolve_version.outputs.version }}.tar.gz
+            gsm3-management-panel-windows-v${{ needs.resolve_version.outputs.version }}.zip
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -211,6 +211,10 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 # ---------- 构建阶段 ----------
 FROM base AS builder
 
+ARG APP_VERSION=development
+ENV APP_VERSION=${APP_VERSION} \
+    VITE_APP_VERSION=${APP_VERSION}
+
 # 拷贝源码用于构建
 COPY --chown=steam:steam . /app/
 USER ${STEAM_USER}
@@ -233,6 +237,10 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 
 # ---------- 运行阶段（最终镜像） ----------
 FROM base AS runtime
+
+ARG APP_VERSION=development
+ENV APP_VERSION=${APP_VERSION}
+LABEL org.opencontainers.image.version=${APP_VERSION}
 
 # 仅在AMD64架构上安装并初始化 SteamCMD
 RUN if [ "$TARGETARCH" = "amd64" ]; then \

--- a/client/src/config/buildInfo.ts
+++ b/client/src/config/buildInfo.ts
@@ -1,0 +1,9 @@
+const normalizeVersion = (value?: string): string => {
+  return value?.trim().replace(/^v(?=\d)/i, '') || ''
+}
+
+const injectedVersion = normalizeVersion(__GSM3_BUILD_VERSION__)
+
+export const buildInfo = Object.freeze({
+  version: injectedVersion || (import.meta.env.DEV ? '开发版本' : '未标记版本')
+})

--- a/client/src/pages/AboutProjectPage.tsx
+++ b/client/src/pages/AboutProjectPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Github, Info, Heart, Star, GitFork, Eye, ExternalLink, BookOpen } from 'lucide-react'
+import { buildInfo } from '../config/buildInfo'
 
 const AboutProjectPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState('docs')
@@ -254,7 +255,7 @@ const AboutProjectPage: React.FC = () => {
                     </div>
                     <div className="flex justify-between">
                       <span className="text-gray-600 dark:text-gray-400">版本：</span>
-                      <span className="text-black dark:text-white font-medium">3.13.0</span>
+                      <span className="text-black dark:text-white font-medium">{buildInfo.version}</span>
                     </div>
                     <div className="flex justify-between">
                       <span className="text-gray-600 dark:text-gray-400">开发者：</span>

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,8 +1,11 @@
 /// <reference types="vite/client" />
 
+declare const __GSM3_BUILD_VERSION__: string
+
 interface ImportMetaEnv {
   readonly VITE_SERVER_PORT?: string
   readonly VITE_CLIENT_PORT?: string
+  readonly VITE_APP_VERSION?: string
   // 更多环境变量可以在这里添加
 }
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const { resolveBuildVersion } = require('../scripts/resolve-build-version.js') as {
+  resolveBuildVersion: (options?: { cwd?: string; env?: NodeJS.ProcessEnv }) => string
+}
 
 // 获取后端服务端口
 const getServerPort = () => {
@@ -14,6 +20,10 @@ const getClientPort = () => {
 
 const serverPort = getServerPort()
 const clientPort = getClientPort()
+const buildVersion = resolveBuildVersion({
+  cwd: path.resolve(__dirname, '..'),
+  env: process.env
+})
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -27,6 +37,7 @@ export default defineConfig({
     global: 'globalThis',
     'process.env': {},
     'process.platform': JSON.stringify(process.platform),
+    __GSM3_BUILD_VERSION__: JSON.stringify(buildVersion),
   },
   server: {
     host: '0.0.0.0', // 允许网络访问

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -6,10 +6,11 @@ const https = require('https')
 const { pipeline } = require('stream')
 const { promisify } = require('util')
 const iconv = require('iconv-lite')
+const { resolveBuildVersion } = require('./resolve-build-version')
 const pipelineAsync = promisify(pipeline)
 
 const packageName = 'gsm3-management-panel'
-const version = require('../package.json').version
+const version = resolveBuildVersion()
 const distDir = path.join(__dirname, '..', 'dist')
 const packageDir = path.join(distDir, 'package')
 

--- a/scripts/resolve-build-version.js
+++ b/scripts/resolve-build-version.js
@@ -1,0 +1,105 @@
+const fs = require('fs')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+const projectRoot = path.join(__dirname, '..')
+const packageVersion = require('../package.json').version
+
+function normalizeBuildVersion(value) {
+  return String(value || '')
+    .trim()
+    .replace(/^refs\/tags\//i, '')
+    .replace(/^v(?=\d)/i, '')
+    .replace(/[^0-9A-Za-z._-]+/g, '-')
+    .replace(/^[._-]+|[._-]+$/g, '')
+    .slice(0, 100)
+}
+
+function readGitDescription(cwd) {
+  try {
+    const result = execFileSync(
+      'git',
+      ['describe', '--tags', '--always', '--dirty', '--long'],
+      {
+        cwd,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore']
+      }
+    )
+    const version = normalizeBuildVersion(result)
+    const exactCleanTag = version.match(/^(.*)-0-g[0-9a-f]+$/i)
+    return exactCleanTag?.[1] || version
+  } catch {
+    // Source archives may not include Git metadata; use the package fallback.
+  }
+
+  return ''
+}
+
+function resolveBuildMetadata(options = {}) {
+  const env = options.env || process.env
+  const cwd = options.cwd || projectRoot
+  const candidates = [
+    { value: env.BUILD_VERSION, isTag: false },
+    { value: env.RELEASE_TAG, isTag: true },
+    {
+      value: env.GITHUB_REF_TYPE === 'tag' ? env.GITHUB_REF_NAME : '',
+      isTag: true
+    },
+    { value: env.APP_VERSION, isTag: false },
+    { value: env.VITE_APP_VERSION, isTag: false }
+  ]
+
+  for (const candidate of candidates) {
+    const version = normalizeBuildVersion(candidate.value)
+    if (version) {
+      return {
+        version,
+        isStable: candidate.isTag && isStableTagVersion(env, version)
+      }
+    }
+  }
+
+  const gitVersion = readGitDescription(cwd)
+  if (gitVersion) {
+    const commitOnly = gitVersion.match(/^([0-9a-f]{7,40})(-dirty)?$/i)
+    const version = commitOnly
+      ? `dev-${commitOnly[1].slice(0, 12)}${commitOnly[2] || ''}`
+      : gitVersion
+    return { version, isStable: false }
+  }
+
+  return {
+    version: normalizeBuildVersion(packageVersion) || 'development',
+    isStable: false
+  }
+}
+
+function isStableTagVersion(env, version) {
+  const isPrerelease = String(env.RELEASE_PRERELEASE || '').toLowerCase() === 'true'
+  return !isPrerelease && /^\d+\.\d+\.\d+$/.test(version)
+}
+
+function resolveBuildVersion(options = {}) {
+  return resolveBuildMetadata(options).version
+}
+
+function appendGitHubValue(filePath, name, value) {
+  if (!filePath) return
+  fs.appendFileSync(filePath, `${name}=${value}\n`, 'utf8')
+}
+
+if (require.main === module) {
+  const metadata = resolveBuildMetadata()
+  appendGitHubValue(process.env.GITHUB_OUTPUT, 'version', metadata.version)
+  appendGitHubValue(process.env.GITHUB_OUTPUT, 'is_stable', String(metadata.isStable))
+  appendGitHubValue(process.env.GITHUB_ENV, 'APP_VERSION', metadata.version)
+  appendGitHubValue(process.env.GITHUB_ENV, 'VITE_APP_VERSION', metadata.version)
+  console.log(`Resolved build version: ${metadata.version} (stable tag: ${metadata.isStable})`)
+}
+
+module.exports = {
+  normalizeBuildVersion,
+  resolveBuildMetadata,
+  resolveBuildVersion
+}


### PR DESCRIPTION
## 变更说明

将“关于项目”中的硬编码版本号改为构建版本，并由 GitHub Actions 自动解析与注入，后续发布不再需要同步修改面板和 Docker workflow 中的版本字符串。

### 版本来源

1. GitHub Release tag / tag push（如 `v3.13.0` → `3.13.0`）
2. 手动构建时回退到 `git describe --tags --always --dirty --long`
3. 无 Git 元数据时回退根 `package.json`

### CI/CD

- 新增独立 `resolve_version` job，只解析一次版本并传给 Linux、Windows、Docker 构建。
- 注入 `APP_VERSION` 与 `VITE_APP_VERSION`。
- Docker 镜像使用动态版本 tag，并写入运行环境及 OCI version label。
- 仅稳定的 `x.y.z` tag 构建更新 `latest`；手动分支构建、显式覆盖版本和预发布版本不会覆盖 `latest`。
- GitHub Release 附件名自动包含版本号。

### 面板

- Vite 构建阶段把解析后的版本注入 `__GSM3_BUILD_VERSION__`。
- “关于项目 → 项目信息”直接显示构建版本，不再手动维护版本号。

## 验证

- 版本规范化、GitHub output/env 写入验证通过。
- 精确 tag 的干净工作区显示正式版本；dirty 工作区保留 commit 与 `dirty` 标记。
- 稳定 tag / prerelease / 手动分支 / 显式覆盖版本的 `latest` 分类验证通过。
- GitHub Actions YAML 解析及依赖、Docker tag/build-arg、版本化 Release 附件断言通过。
- `docker buildx build --check --build-arg APP_VERSION=9.8.7 .` 通过。
- `cd client && npx tsc --noEmit` 通过。
- `cd server && npx tsc --noEmit` 通过。
- `APP_VERSION=v9.8.7 VITE_APP_VERSION=v9.8.7 npm run build` 通过，产物包含 `9.8.7`，且不再包含旧的硬编码面板版本。
- 独立代码/安全审查与 MoA 复核：APPROVE。
