### PR TITLE
fix(build): include built-in plugins in release packages

### DIFF
--- a/scripts/package.js
+++ b/scripts/package.js
@@ -398,6 +398,20 @@ async function createPackage() {
     } else {
       console.log('⚠️  警告: server/data/gameconfig 目录不存在，跳过复制')
     }
+
+    // 复制内置插件到打包根目录的data/下
+    // Docker 会从该不可挂载目录向持久卷补充缺失的内置插件
+    const serverPluginsPath = path.join(__dirname, '..', 'server', 'data', 'plugins')
+    if (await fs.pathExists(serverPluginsPath)) {
+      await fs.ensureDir(path.join(packageDir, 'data'))
+      await fs.copy(
+        serverPluginsPath,
+        path.join(packageDir, 'data', 'plugins')
+      )
+      console.log('🧩 复制内置插件文件...')
+    } else {
+      console.log('⚠️  警告: server/data/plugins 目录不存在，跳过复制')
+    }
     
     console.log('📥 安装服务端生产依赖...')
     // 在打包的服务端目录中安装生产依赖

--- a/start.sh
+++ b/start.sh
@@ -13,6 +13,26 @@ if [ -f "server/index.js" ]; then
     echo "📍 访问地址: http://localhost:3001"
     echo "📍 默认账户: admin / admin123"
     echo
+
+    # Docker 的持久卷会遮蔽镜像内的 server/data，补充卷中缺失的内置插件。
+    # 仅复制不存在的插件目录，避免覆盖用户配置或自行安装的插件。
+    DEFAULT_PLUGINS_DIR="data/plugins"
+    RUNTIME_PLUGINS_DIR="server/data/plugins"
+    if [ -d "$DEFAULT_PLUGINS_DIR" ]; then
+        mkdir -p "$RUNTIME_PLUGINS_DIR"
+        for plugin_dir in "$DEFAULT_PLUGINS_DIR"/*; do
+            if [ ! -d "$plugin_dir" ] || [ ! -f "$plugin_dir/plugin.json" ]; then
+                continue
+            fi
+
+            plugin_name=$(basename "$plugin_dir")
+            runtime_plugin_dir="$RUNTIME_PLUGINS_DIR/$plugin_name"
+            if [ ! -e "$runtime_plugin_dir" ]; then
+                cp -a "$plugin_dir" "$runtime_plugin_dir"
+                echo "✅ 已补充内置插件: $plugin_name"
+            fi
+        done
+    fi
     
     # PTY 文件已迁移到 data/lib/ 目录，启动时由服务端自动检测和下载
     # 如果 data/lib/ 中存在 PTY 文件，验证并设置可执行权限


### PR DESCRIPTION
## What

- 将 `server/data/plugins` 复制到独立发布包的 `data/plugins`。
- Docker 启动时从镜像内的默认插件目录补充持久卷中缺失的内置插件。
- 仅补充不存在的插件目录，不覆盖用户配置或自行安装的插件。

## Why

Linux/Windows 发布包此前没有复制插件资源，因此 `tunnel-helper`（frp / EasyTier）不会出现在产物中。Docker 虽然在镜像层包含插件，但已有的 `/root/server/data` 持久卷会遮蔽镜像内容，旧卷升级后仍然缺少该插件。

## Verification

- `bash -n start.sh`
- `node --check scripts/package.js`
- `cd server && npx tsc --noEmit`
- `cd client && npx tsc --noEmit`
- `npm run build`
- Windows 完整打包成功，ZIP 完整性校验通过
- 已确认 `data/plugins/tunnel-helper/{gsm3-api.js,index.html,plugin.json}` 与源码一致
- 已模拟旧 Docker 数据卷：缺失插件成功补充，已有插件内容保持不变
- 独立代码审查：APPROVE
