### PR TITLE
refactor(steam): extract reusable branch selector

### DIFF
--- a/client/src/components/SteamBranchSelector.tsx
+++ b/client/src/components/SteamBranchSelector.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useRef, useState } from 'react'
+import { ChevronDown, Loader, RefreshCw } from 'lucide-react'
+import type { SteamBranchInfo } from '@/types'
+
+interface SteamBranchSelectorProps {
+  id: string
+  value: string
+  branches: SteamBranchInfo[]
+  loading: boolean
+  error: string
+  disabled?: boolean
+  refreshDisabled?: boolean
+  onChange: (branch: string) => void
+  onRefresh: () => void
+}
+
+export default function SteamBranchSelector({
+  id,
+  value,
+  branches,
+  loading,
+  error,
+  disabled = false,
+  refreshDisabled = false,
+  onChange,
+  onRefresh
+}: SteamBranchSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const toggleButtonRef = useRef<HTMLButtonElement>(null)
+  const listId = `${id}-list`
+  const statusId = `${id}-status`
+
+  useEffect(() => {
+    if (disabled) setIsOpen(false)
+  }, [disabled])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      const shouldRestoreToggleFocus = document.activeElement !== inputRef.current
+      setIsOpen(false)
+      if (shouldRestoreToggleFocus) toggleButtonRef.current?.focus()
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen])
+
+  const statusText = loading
+    ? '正在发现可见分支...'
+    : error
+    ? `${error}；仍可手动输入已知分支`
+    : refreshDisabled && branches.length === 0
+    ? '请先填写Steam用户名和密码，再查询可见分支'
+    : `已发现 ${branches.length} 个可见分支；私有分支可直接输入名称`
+
+  return (
+    <div ref={containerRef} className="space-y-2">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          ref={inputRef}
+          id={id}
+          type="text"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          disabled={disabled}
+          autoComplete="off"
+          aria-describedby={statusId}
+          className="min-w-0 flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-white disabled:opacity-60"
+          placeholder={loading ? '正在发现可见分支...' : '输入Steam分支名称'}
+        />
+        <button
+          ref={toggleButtonRef}
+          type="button"
+          onClick={() => setIsOpen(current => !current)}
+          disabled={disabled}
+          aria-expanded={isOpen}
+          aria-controls={isOpen ? listId : undefined}
+          className="min-h-11 flex-shrink-0 inline-flex items-center justify-center gap-2 px-4 py-2 bg-gray-100 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          <ChevronDown aria-hidden="true" className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+          <span>{isOpen ? '收起分支' : `查看分支${branches.length > 0 ? ` (${branches.length})` : ''}`}</span>
+        </button>
+      </div>
+
+      {isOpen && (
+        <div
+          id={listId}
+          className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-600 dark:bg-gray-700"
+        >
+          <div className="flex min-h-11 items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-600 dark:bg-gray-700/70">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              可见分支 ({branches.length})
+            </span>
+            <button
+              type="button"
+              onClick={onRefresh}
+              disabled={loading || refreshDisabled || disabled}
+              className="inline-flex min-h-9 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-blue-600 transition-colors hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:text-blue-300 dark:hover:bg-blue-900/30"
+            >
+              {loading
+                ? <Loader aria-hidden="true" className="h-4 w-4 animate-spin" />
+                : <RefreshCw aria-hidden="true" className="h-4 w-4" />}
+              <span>重新查询</span>
+            </button>
+          </div>
+
+          {loading && branches.length === 0 ? (
+            <div className="flex items-center justify-center gap-2 px-3 py-6 text-sm text-gray-500 dark:text-gray-300" role="status">
+              <Loader aria-hidden="true" className="h-4 w-4 animate-spin" />
+              <span>正在查询可见分支...</span>
+            </div>
+          ) : branches.length > 0 ? (
+            <select
+              value={value.trim()}
+              size={Math.min(branches.length, 6)}
+              aria-label="选择已查询到的Steam分支"
+              onChange={(event) => onChange(event.target.value)}
+              disabled={disabled}
+              className="block max-h-56 w-full border-0 bg-white px-2 py-1 text-sm text-gray-700 focus:ring-2 focus:ring-inset focus:ring-blue-500 dark:bg-gray-700 dark:text-gray-200"
+            >
+              {branches.map(branchInfo => (
+                <option key={branchInfo.name} value={branchInfo.name} className="py-2">
+                  {branchInfo.name}
+                  {branchInfo.isDefault ? ' · 默认' : ''}
+                  {branchInfo.requiresPassword ? ' · 需密码' : ''}
+                  {branchInfo.description && branchInfo.description !== branchInfo.name ? ` · ${branchInfo.description}` : ''}
+                  {branchInfo.buildId ? ` · Build ${branchInfo.buildId}` : ''}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <div className="px-3 py-5 text-sm text-gray-500 dark:text-gray-300">
+              {refreshDisabled
+                ? '请先填写Steam用户名和密码，再重新查询可见分支。'
+                : error
+                ? '分支查询失败，可直接在上方输入已知分支名称。'
+                : '没有查询到可见分支，可直接在上方输入已知分支名称。'}
+            </div>
+          )}
+        </div>
+      )}
+
+      <p
+        id={statusId}
+        aria-live="polite"
+        className={`text-xs ${error ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400'}`}
+      >
+        {statusText}
+      </p>
+    </div>
+  )
+}

--- a/client/src/pages/GameDeploymentPage.tsx
+++ b/client/src/pages/GameDeploymentPage.tsx
@@ -32,6 +32,7 @@ import CloudProviderModal from '@/components/CloudProviderModal'
 import ConfirmInstanceUpdateDialog from '@/components/ConfirmInstanceUpdateDialog'
 import FileDeploymentConflictDialog from '@/components/FileDeploymentConflictDialog'
 import NetworkStatusBanner from '@/components/NetworkStatusBanner'
+import SteamBranchSelector from '@/components/SteamBranchSelector'
 
 interface GameInfo {
   game_nameCN: string
@@ -6114,58 +6115,32 @@ const GameDeploymentPage: React.FC = () => {
 
               {/* Steam分支选择 */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                <label htmlFor="steam-install-branch" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                   服务器版本（Steam分支）
                 </label>
-                <div className="flex gap-2">
-                  <input
-                    type="text"
-                    list="steam-install-branch-options"
-                    value={selectedSteamBranch}
-                    onChange={(e) => {
-                      setSelectedSteamBranch(e.target.value)
-                      setSteamBranchPassword('')
-                    }}
-                    disabled={installing}
-                    className="min-w-0 flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-white disabled:opacity-60"
-                    placeholder={steamBranchesLoading ? '正在发现可见分支...' : '输入Steam分支名称'}
-                  />
-                  <datalist id="steam-install-branch-options">
-                    {steamBranches.map(branchInfo => (
-                      <option
-                        key={branchInfo.name}
-                        value={branchInfo.name}
-                        label={`${branchInfo.description || branchInfo.name}${branchInfo.buildId ? ` (Build ${branchInfo.buildId})` : ''}`}
-                      />
-                    ))}
-                  </datalist>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      void loadSteamBranches(selectedGame.info.appid, {
-                        forceRefresh: true,
-                        preferredBranch: selectedSteamBranch,
-                        credentials: useAnonymous ? undefined : {
-                          steamUsername: steamUsername.trim(),
-                          steamPassword
-                        }
-                      })
-                    }}
-                    disabled={steamBranchesLoading || installing || (!useAnonymous && (!steamUsername.trim() || !steamPassword))}
-                    className="w-10 h-10 flex-shrink-0 inline-flex items-center justify-center bg-gray-100 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    title={useAnonymous ? '重新发现Steam分支' : '使用当前Steam账户重新发现分支'}
-                    aria-label="重新发现Steam分支"
-                  >
-                    <RefreshCw className={`w-4 h-4 ${steamBranchesLoading ? 'animate-spin' : ''}`} />
-                  </button>
-                </div>
-                <p className={`text-xs mt-1 ${steamBranchesError ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400'}`}>
-                  {steamBranchesLoading
-                    ? '正在发现可见分支...'
-                    : steamBranchesError
-                    ? `${steamBranchesError}；仍可手动输入已知分支`
-                    : `已发现 ${steamBranches.length} 个可见分支；私有分支可直接输入名称`}
-                </p>
+                <SteamBranchSelector
+                  id="steam-install-branch"
+                  value={selectedSteamBranch}
+                  branches={steamBranches}
+                  loading={steamBranchesLoading}
+                  error={steamBranchesError}
+                  disabled={installing}
+                  refreshDisabled={!useAnonymous && (!steamUsername.trim() || !steamPassword)}
+                  onChange={(branch) => {
+                    setSelectedSteamBranch(branch)
+                    setSteamBranchPassword('')
+                  }}
+                  onRefresh={() => {
+                    void loadSteamBranches(selectedGame.info.appid, {
+                      forceRefresh: true,
+                      preferredBranch: selectedSteamBranch,
+                      credentials: useAnonymous ? undefined : {
+                        steamUsername: steamUsername.trim(),
+                        steamPassword
+                      }
+                    })
+                  }}
+                />
               </div>
 
               {Boolean(selectedSteamBranch.trim()) && selectedSteamBranch.trim() !== 'public' && (

--- a/client/src/pages/InstanceManagerPage.tsx
+++ b/client/src/pages/InstanceManagerPage.tsx
@@ -33,6 +33,7 @@ import { CreateConfigDialog } from '@/components/CreateConfigDialog'
 import SearchableSelect from '@/components/SearchableSelect'
 import RconConsole from '@/components/RconConsole'
 import ConfirmDialog from '@/components/ConfirmDialog'
+import SteamBranchSelector from '@/components/SteamBranchSelector'
 import { formatFileSize } from '@/utils/format'
 import { io, Socket } from 'socket.io-client'
 import config from '@/config'
@@ -2860,55 +2861,29 @@ const InstanceManagerPage: React.FC = () => {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                <label htmlFor="steam-update-branch" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                   服务器版本（Steam分支）
                 </label>
-                <div className="flex gap-2">
-                  <input
-                    type="text"
-                    list="steam-update-branch-options"
-                    value={steamUpdateBranch}
-                    onChange={(e) => {
-                      setSteamUpdateBranch(e.target.value)
-                      setSteamUpdateBranchPassword('')
-                    }}
-                    disabled={steamUpdating}
-                    className="min-w-0 flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:opacity-60"
-                    placeholder={steamUpdateLoadingBranches ? '正在发现可见分支...' : '输入Steam分支名称'}
-                  />
-                  <datalist id="steam-update-branch-options">
-                    {steamUpdateBranches.map(branchInfo => (
-                      <option
-                        key={branchInfo.name}
-                        value={branchInfo.name}
-                        label={`${branchInfo.description || branchInfo.name}${branchInfo.buildId ? ` (Build ${branchInfo.buildId})` : ''}`}
-                      />
-                    ))}
-                  </datalist>
-                  <button
-                    type="button"
-                    onClick={() => void loadSteamUpdateBranches(steamUpdateInstance, {
-                      forceRefresh: true,
-                      credentials: steamUpdateUseAnonymous ? undefined : {
-                        steamUsername: steamUpdateUsername.trim(),
-                        steamPassword: steamUpdatePassword
-                      }
-                    })}
-                    disabled={steamUpdateLoadingBranches || steamUpdating || (!steamUpdateUseAnonymous && (!steamUpdateUsername.trim() || !steamUpdatePassword))}
-                    className="w-10 h-10 flex-shrink-0 inline-flex items-center justify-center bg-gray-100 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    title={steamUpdateUseAnonymous ? '重新发现Steam分支' : '使用当前Steam账户重新发现分支'}
-                    aria-label="重新发现Steam分支"
-                  >
-                    <RefreshCw className={`w-4 h-4 ${steamUpdateLoadingBranches ? 'animate-spin' : ''}`} />
-                  </button>
-                </div>
-                <p className={`text-xs mt-1 ${steamUpdateBranchesError ? 'text-amber-600 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400'}`}>
-                  {steamUpdateLoadingBranches
-                    ? '正在发现可见分支...'
-                    : steamUpdateBranchesError
-                    ? `${steamUpdateBranchesError}；仍可手动输入已知分支`
-                    : `已发现 ${steamUpdateBranches.length} 个可见分支；私有分支可直接输入名称`}
-                </p>
+                <SteamBranchSelector
+                  id="steam-update-branch"
+                  value={steamUpdateBranch}
+                  branches={steamUpdateBranches}
+                  loading={steamUpdateLoadingBranches}
+                  error={steamUpdateBranchesError}
+                  disabled={steamUpdating}
+                  refreshDisabled={!steamUpdateUseAnonymous && (!steamUpdateUsername.trim() || !steamUpdatePassword)}
+                  onChange={(branch) => {
+                    setSteamUpdateBranch(branch)
+                    setSteamUpdateBranchPassword('')
+                  }}
+                  onRefresh={() => void loadSteamUpdateBranches(steamUpdateInstance, {
+                    forceRefresh: true,
+                    credentials: steamUpdateUseAnonymous ? undefined : {
+                      steamUsername: steamUpdateUsername.trim(),
+                      steamPassword: steamUpdatePassword
+                    }
+                  })}
+                />
               </div>
 
               {Boolean(steamUpdateBranch.trim()) && steamUpdateBranch.trim() !== 'public' && (


### PR DESCRIPTION
## 概要

将游戏部署页和实例管理页中重复的 Steam 分支选择逻辑提取为可复用组件，保持两个入口的交互和行为一致。

## 主要变更

- 新增 `SteamBranchSelector` 组件
- 在 `GameDeploymentPage` 和 `InstanceManagerPage` 中复用统一组件
- 保留手动输入私有分支名称的能力
- 统一可见分支查询、刷新、加载与错误状态
- 补充键盘 Escape、焦点恢复、ARIA 状态和暗色主题支持

## 验证

- [x] `npm --prefix client run build`
- [x] `git diff --check origin/main..HEAD`
- [x] 分支仅包含一个独立提交和 3 个前端文件
