### PR TITLE
fix(release): publish only versioned platform archives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
 
   # 创建发布版本（仅在推送标签时触发）
   create_release:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [resolve_version, build_linux, build_windows]
     runs-on: ubuntu-latest
     steps:
@@ -232,9 +232,7 @@ jobs:
       - name: Create platform archives
         run: |
           tar -czf gsm3-management-panel-linux-x64-v${{ needs.resolve_version.outputs.version }}.tar.gz -C linux-x64-build .
-          cp gsm3-management-panel-linux-x64-v${{ needs.resolve_version.outputs.version }}.tar.gz gsm3-management-panel-linux-x64.tar.gz
           tar -czf gsm3-management-panel-linux-arm64-v${{ needs.resolve_version.outputs.version }}.tar.gz -C linux-arm64-build .
-          cp gsm3-management-panel-linux-arm64-v${{ needs.resolve_version.outputs.version }}.tar.gz gsm3-management-panel-linux-arm64.tar.gz
           cd windows-build
           zip -r ../gsm3-management-panel-windows-v${{ needs.resolve_version.outputs.version }}.zip .
       - name: Create Release
@@ -242,9 +240,7 @@ jobs:
         with:
           files: |
             gsm3-management-panel-linux-x64-v${{ needs.resolve_version.outputs.version }}.tar.gz
-            gsm3-management-panel-linux-x64.tar.gz
             gsm3-management-panel-linux-arm64-v${{ needs.resolve_version.outputs.version }}.tar.gz
-            gsm3-management-panel-linux-arm64.tar.gz
             gsm3-management-panel-windows-v${{ needs.resolve_version.outputs.version }}.zip
           generate_release_notes: true
           draft: false

--- a/docs/PTY集成说明.md
+++ b/docs/PTY集成说明.md
@@ -46,7 +46,7 @@ npm run package:linux:arm64  # ensure --asset linux-arm64
 npm run package:windows      # ensure --asset win32-x64
 ```
 
-每个 Linux 包只包含对应架构的 Node.js、PTY、Zip-Tools 和 7z：x64 发布归档为 `gsm3-management-panel-linux-x64.tar.gz`，ARM64 发布归档为 `gsm3-management-panel-linux-arm64.tar.gz`。Windows 包包含 `win32-x64` PTY；未指定目标时的通用开发入口仍可包含全部资产。任何 PTY 资产无法校验、下载或进行适用的本机探测时，打包操作失败，不生成声称已包含 PTY 的产物。
+每个 Linux 包只包含对应架构的 Node.js、PTY、Zip-Tools 和 7z：x64 发布归档为 `gsm3-management-panel-linux-x64-v<version>.tar.gz`，ARM64 发布归档为 `gsm3-management-panel-linux-arm64-v<version>.tar.gz`。Windows 发布归档为 `gsm3-management-panel-windows-v<version>.zip` 并包含 `win32-x64` PTY。Release 对每个系统和架构只上传带版本号的归档；未指定目标时的通用开发入口仍可包含全部资产。任何 PTY 资产无法校验、下载或进行适用的本机探测时，打包操作失败，不生成声称已包含 PTY 的产物。
 
 ### Docker 镜像
 
@@ -60,7 +60,7 @@ node /root/server/utils/ptyAssetCli.js ensure --asset <asset-key> --target-dir /
 
 ### 常规安装脚本
 
-`install-gsm3.sh` 在下载前读取 `uname -m`：`x86_64/amd64` 选择 `gsm3-management-panel-linux-x64.tar.gz` 与 `linux-x64`，`aarch64/arm64` 选择 `gsm3-management-panel-linux-arm64.tar.gz` 与 `linux-arm64`；其他架构直接退出。解压并启用包内 Node.js 后调用：
+`install-gsm3.sh` 先通过 GitHub Releases API 获取最新稳定标签，再读取 `uname -m`：`x86_64/amd64` 选择 `gsm3-management-panel-linux-x64-v<version>.tar.gz` 与 `linux-x64`，`aarch64/arm64` 选择 `gsm3-management-panel-linux-arm64-v<version>.tar.gz` 与 `linux-arm64`；其他架构直接退出。解压并启用包内 Node.js 后调用：
 
 ```text
 <install-path>/node/bin/node <install-path>/server/utils/ptyAssetCli.js ensure --asset <asset-key> --target-dir <install-path>/data/lib

--- a/docs/PTY集成说明.md
+++ b/docs/PTY集成说明.md
@@ -60,7 +60,7 @@ node /root/server/utils/ptyAssetCli.js ensure --asset <asset-key> --target-dir /
 
 ### 常规安装脚本
 
-`install-gsm3.sh` 先通过 GitHub Releases API 获取最新稳定标签，再读取 `uname -m`：`x86_64/amd64` 选择 `gsm3-management-panel-linux-x64-v<version>.tar.gz` 与 `linux-x64`，`aarch64/arm64` 选择 `gsm3-management-panel-linux-arm64-v<version>.tar.gz` 与 `linux-arm64`；其他架构直接退出。解压并启用包内 Node.js 后调用：
+`install-gsm3.sh` 优先通过 GitHub Releases API 获取最新稳定标签；API 不可用时，会从 GitHub Releases `latest` 页面（含镜像地址）的重定向 URL 解析标签。随后读取 `uname -m`：`x86_64/amd64` 选择 `gsm3-management-panel-linux-x64-v<version>.tar.gz` 与 `linux-x64`，`aarch64/arm64` 选择 `gsm3-management-panel-linux-arm64-v<version>.tar.gz` 与 `linux-arm64`；其他架构直接退出。解压并启用包内 Node.js 后调用：
 
 ```text
 <install-path>/node/bin/node <install-path>/server/utils/ptyAssetCli.js ensure --asset <asset-key> --target-dir <install-path>/data/lib

--- a/install-gsm3.sh
+++ b/install-gsm3.sh
@@ -105,14 +105,67 @@ mkdir -pv "$install_path"
 cd "$install_path"
 
 if test "$install_type" = "1"; then
+	RELEASE_API_URL="https://api.github.com/repos/GSManagerXZ/GameServerManager/releases/latest"
+	RELEASE_API_MIRROR_URL="https://ghfast.top/https://api.github.com/repos/GSManagerXZ/GameServerManager/releases/latest"
+	RELEASE_METADATA=""
+
+	fetch_release_metadata() {
+		local url
+		for url in "$RELEASE_API_URL" "$RELEASE_API_MIRROR_URL"; do
+			if command -v curl &>/dev/null; then
+				if RELEASE_METADATA=$(curl -fsSL \
+					-H "Accept: application/vnd.github+json" \
+					-H "User-Agent: gsm3-installer" \
+					"$url"); then
+					return 0
+				fi
+			elif command -v wget &>/dev/null; then
+				if RELEASE_METADATA=$(wget -qO- \
+					--header="Accept: application/vnd.github+json" \
+					--header="User-Agent: gsm3-installer" \
+					"$url"); then
+					return 0
+				fi
+			else
+				echo -e "\x1b[31m错误：既没有安装curl也没有安装wget，无法查询GSM3最新版本！\x1b[0m"
+				return 1
+			fi
+		done
+		return 1
+	}
+
+	if ! fetch_release_metadata; then
+		echo -e "\x1b[31m无法查询GSM3最新稳定版本，请检查网络后重试！\x1b[0m"
+		exit 1
+	fi
+
+	RELEASE_TAG=$(printf '%s' "$RELEASE_METADATA" \
+		| grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' \
+		| head -n 1 \
+		| sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)"/\1/')
+	RELEASE_VERSION="${RELEASE_TAG#v}"
+	case "$RELEASE_TAG" in
+		v[0-9]*) ;;
+		*)
+			echo -e "\x1b[31m无法识别最新版本标签: $RELEASE_TAG\x1b[0m"
+			exit 1
+			;;
+	esac
+	case "$RELEASE_VERSION" in
+		""|*[!0-9A-Za-z._-]*)
+			echo -e "\x1b[31m最新版本号包含非法字符: $RELEASE_VERSION\x1b[0m"
+			exit 1
+			;;
+	esac
+
 	ARCH=$(uname -m)
 	case "$ARCH" in
 		x86_64|amd64)
-			ARCHIVE_NAME="gsm3-management-panel-linux-x64.tar.gz"
+			PACKAGE_TARGET="linux-x64"
 			PTY_ASSET="linux-x64"
 			;;
 		aarch64|arm64)
-			ARCHIVE_NAME="gsm3-management-panel-linux-arm64.tar.gz"
+			PACKAGE_TARGET="linux-arm64"
 			PTY_ASSET="linux-arm64"
 			;;
 		*)
@@ -120,7 +173,9 @@ if test "$install_type" = "1"; then
 			exit 1
 			;;
 	esac
-	DOWNLOAD_URL="https://ghfast.top/https://github.com/GSManagerXZ/GameServerManager/releases/latest/download/$ARCHIVE_NAME"
+	ARCHIVE_NAME="gsm3-management-panel-${PACKAGE_TARGET}-v${RELEASE_VERSION}.tar.gz"
+	DOWNLOAD_URL="https://ghfast.top/https://github.com/GSManagerXZ/GameServerManager/releases/download/${RELEASE_TAG}/${ARCHIVE_NAME}"
+	echo "检测到最新稳定版本: $RELEASE_TAG，正在下载 $ARCHIVE_NAME"
 
 	if command -v curl &>/dev/null;then
 		curl -fL -o gsm3.tgz "$DOWNLOAD_URL"

--- a/install-gsm3.sh
+++ b/install-gsm3.sh
@@ -106,43 +106,71 @@ cd "$install_path"
 
 if test "$install_type" = "1"; then
 	RELEASE_API_URL="https://api.github.com/repos/GSManagerXZ/GameServerManager/releases/latest"
-	RELEASE_API_MIRROR_URL="https://ghfast.top/https://api.github.com/repos/GSManagerXZ/GameServerManager/releases/latest"
+	RELEASE_PAGE_URL="https://github.com/GSManagerXZ/GameServerManager/releases/latest"
+	RELEASE_PAGE_MIRROR_URL="https://ghfast.top/https://github.com/GSManagerXZ/GameServerManager/releases/latest"
 	RELEASE_METADATA=""
+	RELEASE_TAG=""
 
-	fetch_release_metadata() {
-		local url
-		for url in "$RELEASE_API_URL" "$RELEASE_API_MIRROR_URL"; do
-			if command -v curl &>/dev/null; then
-				if RELEASE_METADATA=$(curl -fsSL \
-					-H "Accept: application/vnd.github+json" \
-					-H "User-Agent: gsm3-installer" \
-					"$url"); then
-					return 0
-				fi
-			elif command -v wget &>/dev/null; then
-				if RELEASE_METADATA=$(wget -qO- \
-					--header="Accept: application/vnd.github+json" \
-					--header="User-Agent: gsm3-installer" \
-					"$url"); then
-					return 0
-				fi
-			else
-				echo -e "\x1b[31m错误：既没有安装curl也没有安装wget，无法查询GSM3最新版本！\x1b[0m"
-				return 1
+	extract_release_tag_from_metadata() {
+		printf '%s' "$1" \
+			| grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' \
+			| head -n 1 \
+			| sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)"/\1/'
+	}
+
+	extract_release_tag_from_url() {
+		printf '%s' "$1" \
+			| grep -o 'releases/tag/v[0-9][0-9A-Za-z._-]*' \
+			| tail -n 1 \
+			| sed 's#releases/tag/##'
+	}
+
+	resolve_latest_release_tag() {
+		local url response
+
+		if command -v curl &>/dev/null; then
+			if RELEASE_METADATA=$(curl -fsSL \
+				-H "Accept: application/vnd.github+json" \
+				-H "User-Agent: gsm3-installer" \
+				"$RELEASE_API_URL"); then
+				RELEASE_TAG=$(extract_release_tag_from_metadata "$RELEASE_METADATA")
+				case "$RELEASE_TAG" in v[0-9]*) return 0;; esac
 			fi
-		done
+
+			for url in "$RELEASE_PAGE_URL" "$RELEASE_PAGE_MIRROR_URL"; do
+				if response=$(curl -fsSL --max-time 30 -o /dev/null -w '%{url_effective}' "$url"); then
+					RELEASE_TAG=$(extract_release_tag_from_url "$response")
+					case "$RELEASE_TAG" in v[0-9]*) return 0;; esac
+				fi
+			done
+		elif command -v wget &>/dev/null; then
+			if RELEASE_METADATA=$(wget -qO- \
+				--header="Accept: application/vnd.github+json" \
+				--header="User-Agent: gsm3-installer" \
+				"$RELEASE_API_URL"); then
+				RELEASE_TAG=$(extract_release_tag_from_metadata "$RELEASE_METADATA")
+				case "$RELEASE_TAG" in v[0-9]*) return 0;; esac
+			fi
+
+			for url in "$RELEASE_PAGE_URL" "$RELEASE_PAGE_MIRROR_URL"; do
+				if response=$(wget --server-response --spider --timeout=30 "$url" 2>&1); then
+					RELEASE_TAG=$(extract_release_tag_from_url "$response")
+					case "$RELEASE_TAG" in v[0-9]*) return 0;; esac
+				fi
+			done
+		else
+			echo -e "\x1b[31m错误：既没有安装curl也没有安装wget，无法查询GSM3最新版本！\x1b[0m"
+			return 1
+		fi
+
 		return 1
 	}
 
-	if ! fetch_release_metadata; then
+	if ! resolve_latest_release_tag; then
 		echo -e "\x1b[31m无法查询GSM3最新稳定版本，请检查网络后重试！\x1b[0m"
 		exit 1
 	fi
 
-	RELEASE_TAG=$(printf '%s' "$RELEASE_METADATA" \
-		| grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' \
-		| head -n 1 \
-		| sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)"/\1/')
 	RELEASE_VERSION="${RELEASE_TAG#v}"
 	case "$RELEASE_TAG" in
 		v[0-9]*) ;;

--- a/server/src/utils/ptyControlChannel.ts
+++ b/server/src/utils/ptyControlChannel.ts
@@ -16,6 +16,7 @@ import {
   unlink
 } from 'node:fs/promises'
 import net from 'node:net'
+import os from 'node:os'
 import path from 'node:path'
 
 export interface CreatePtyControlChannelOptions {
@@ -1229,16 +1230,28 @@ class WindowsPtyControlTransport implements PtyControlTransport {
   }
 }
 
+function getDefaultControlDirectoryCandidates(): string[] {
+  const baseDir = process.cwd()
+  const effectiveUserId = typeof process.geteuid === 'function'
+    ? String(process.geteuid())
+    : 'unknown'
+  const candidates = [
+    path.join(baseDir, 'data', 'terminal-control'),
+    path.join(baseDir, 'server', 'data', 'terminal-control'),
+    path.join(baseDir, '..', 'server', 'data', 'terminal-control'),
+    path.join(os.homedir(), '.gsm3', 'terminal-control'),
+    path.join(os.tmpdir(), `gsm3-terminal-control-${effectiveUserId}`)
+  ]
+
+  return [...new Set(candidates.map((candidate) => path.resolve(candidate)))]
+}
+
 async function selectPosixControlDirectory(
   options: CreatePtyControlChannelOptions,
   platform: NodeJS.Platform,
   securityFlags: PosixSecurityFlags
 ): Promise<PosixControlDirectory> {
-  const candidates = [
-    path.join(process.cwd(), 'data', 'terminal-control'),
-    path.join(process.cwd(), 'server', 'data', 'terminal-control')
-  ]
-  const directoryCandidates = options.directoryCandidates ?? candidates
+  const directoryCandidates = options.directoryCandidates ?? getDefaultControlDirectoryCandidates()
 
   for (const rawCandidate of directoryCandidates) {
     let descriptor: number | null = null
@@ -1304,7 +1317,9 @@ async function selectPosixControlDirectory(
 
   throw new PtyControlStageError(
     'directory',
-    `PTY control directory unavailable platform=${platform} sessionId=${options.sessionId} stage=directory`
+    `PTY control directory unavailable platform=${platform} sessionId=${options.sessionId} stage=directory; ` +
+    'checked paths under data/, ~/.gsm3/, and $TMPDIR. ' +
+    'If data/terminal-control was created by another user (e.g. root), remove it or chown it to the panel runtime user.'
   )
 }
 

--- a/server/src/utils/ptyManager.ts
+++ b/server/src/utils/ptyManager.ts
@@ -21,19 +21,29 @@ class PtyManager {
 
   /**
    * 获取 lib 目录的候选路径列表。
-   * 顺序兼容打包后环境和开发环境，不得改变。
+   * 顺序兼容打包、开发、Docker 内置资产和旧版 Docker 布局。
    */
   private getLibDirCandidates(): string[] {
-    const candidates = [
-      path.join(process.cwd(), 'data', 'lib'),
-      path.join(process.cwd(), 'server', 'data', 'lib')
+    const baseDir = process.cwd()
+    return Array.from(new Set([
+      ...this.getWritableLibDirCandidates(),
+      path.join(baseDir, 'builtin', 'data', 'lib'), // 当前 Docker 镜像内置资产目录
+      path.join(baseDir, '..', 'data', 'lib')       // 兼容旧版 Docker/启动脚本布局
+    ]))
+  }
+
+  /** 获取允许服务端下载或替换资产的运行时目录。 */
+  private getWritableLibDirCandidates(): string[] {
+    const baseDir = process.cwd()
+    return [
+      path.join(baseDir, 'data', 'lib'),
+      path.join(baseDir, 'server', 'data', 'lib')
     ]
-    return candidates
   }
 
   /** 优先使用第一个已存在目录；均不存在时创建第一个可写目录。 */
   private async getTargetDir(): Promise<string> {
-    const candidates = this.getLibDirCandidates()
+    const candidates = this.getWritableLibDirCandidates()
 
     for (const candidate of candidates) {
       try {
@@ -69,6 +79,21 @@ class PtyManager {
    */
   async getPtyPath(): Promise<string> {
     const asset = getPtyAsset()
+
+    for (const candidate of this.getLibDirCandidates()) {
+      const targetPath = path.join(candidate, asset.name)
+      if (!await verifyPtyAsset(targetPath, asset)) {
+        continue
+      }
+
+      try {
+        await probePtyAsset(targetPath, asset)
+        return targetPath
+      } catch {
+        logger.warn(`PTY 资产能力探测失败，将尝试其他路径: ${targetPath}`)
+      }
+    }
+
     const targetDir = await this.getTargetDir()
     return ensurePtyAsset({ asset, targetDir, logger })
   }
@@ -92,13 +117,13 @@ class PtyManager {
 
       const targetPath = path.join(candidate, asset.name)
       if (!await verifyPtyAsset(targetPath, asset)) {
-        return false
+        continue
       }
       try {
         await probePtyAsset(targetPath, asset)
         return true
       } catch {
-        return false
+        continue
       }
     }
 

--- a/server/src/utils/zipToolsManager.ts
+++ b/server/src/utils/zipToolsManager.ts
@@ -127,10 +127,12 @@ class ZipToolsManager {
    */
   private getLibDirCandidates(): string[] {
     const baseDir = process.cwd()
-    return [
-      path.join(baseDir, 'data', 'lib'),           // 打包后环境
-      path.join(baseDir, 'server', 'data', 'lib'), // 开发环境
-    ]
+    return Array.from(new Set([
+      path.join(baseDir, 'data', 'lib'),             // 打包后或 Docker 运行时目录
+      path.join(baseDir, 'server', 'data', 'lib'),   // 开发环境目录
+      path.join(baseDir, 'builtin', 'data', 'lib'),  // 当前 Docker 镜像内置资产目录
+      path.join(baseDir, '..', 'data', 'lib'),       // 兼容旧版 Docker/启动脚本布局
+    ]))
   }
 
   /**
@@ -230,7 +232,11 @@ class ZipToolsManager {
       logger.info(`Zip-Tools 下载完成: ${targetPath}`)
     } catch (error: any) {
       // 清理可能的残留文件
-      try { await fs.unlink(targetPath) } catch { /* 忽略 */ }
+      try {
+        await fs.unlink(targetPath)
+      } catch (cleanupError) {
+        logger.debug(`清理 Zip-Tools 残留文件失败: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`)
+      }
       const message = `Zip-Tools 下载失败（GitHub）: ${error.message || error}`
       logger.error(message)
       throw new Error(message)
@@ -342,7 +348,11 @@ class ZipToolsManager {
       logger.info(`7z 下载完成: ${targetPath}`)
     } catch (error: any) {
       // 清理可能的残留文件
-      try { await fs.unlink(targetPath) } catch { /* 忽略 */ }
+      try {
+        await fs.unlink(targetPath)
+      } catch (cleanupError) {
+        logger.debug(`清理 7z 残留文件失败: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`)
+      }
       const message = `7z 下载失败（GitHub）: ${error.message || error}`
       logger.error(message)
       throw new Error(message)

--- a/start.sh
+++ b/start.sh
@@ -7,6 +7,25 @@ echo "    GSM3 游戏服务端管理面板"
 echo "======================================"
 echo
 
+# 将打包内置的 lib 资产同步到运行时目录（Docker 数据卷会覆盖 server/data/lib）
+seed_runtime_lib_assets() {
+    local runtime_lib="$1"
+    local builtin_lib="$2"
+
+    mkdir -p "$runtime_lib"
+    if [ ! -d "$builtin_lib" ]; then
+        return
+    fi
+
+    for asset in "$builtin_lib"/*; do
+        [ -f "$asset" ] || continue
+        local dest="$runtime_lib/$(basename "$asset")"
+        if [ ! -e "$dest" ]; then
+            cp -a "$asset" "$dest"
+        fi
+    done
+}
+
 # 检查是否存在GSM3应用文件
 if [ -f "server/index.js" ]; then
     echo "🚀 启动GSM3管理面板..."
@@ -37,42 +56,18 @@ if [ -f "server/index.js" ]; then
     # Docker 的持久卷会遮蔽镜像内的 server/data，补充卷中缺失的内置运行时资产。
     BUILTIN_LIB_DIR="server/builtin/data/lib"
     RUNTIME_LIB_DIR="server/data/lib"
-    if [ -d "$BUILTIN_LIB_DIR" ]; then
-        mkdir -p "$RUNTIME_LIB_DIR"
-        cp -an "$BUILTIN_LIB_DIR"/. "$RUNTIME_LIB_DIR"/ 2>/dev/null || true
-    fi
+    seed_runtime_lib_assets "$RUNTIME_LIB_DIR" "$BUILTIN_LIB_DIR"
 
-    # PTY 文件已迁移到 data/lib/ 目录，启动时由服务端自动检测和下载
-    # 如果 data/lib/ 中存在 PTY 文件，验证并设置可执行权限
-    ARCH=$(uname -m)
-    if [ "$ARCH" = "x86_64" ]; then
-        PTY_FILE="$RUNTIME_LIB_DIR/pty_linux_x64"
-    elif [ "$ARCH" = "aarch64" ]; then
-        PTY_FILE="$RUNTIME_LIB_DIR/pty_linux_arm64"
-    else
-        PTY_FILE=""
-    fi
+    # PTY 由服务端固定资产管理器校验和探测，避免依赖镜像中未安装的 file 命令。
+    # 内置资产缺失或损坏时，服务端会自动选择可写目录并恢复固定版本。
 
-    if [ -n "$PTY_FILE" ] && [ -f "$PTY_FILE" ]; then
-        # 验证是否为有效的ELF二进制文件
-        if file "$PTY_FILE" 2>/dev/null | grep -q "ELF"; then
-            chmod +x "$PTY_FILE"
-            echo "✅ PTY权限设置完成 ($ARCH)"
-        else
-            echo "⚠️  PTY文件无效（非ELF二进制），已删除，服务启动时将自动重新下载"
-            rm -f "$PTY_FILE"
-        fi
-    else
-        echo "ℹ️  PTY文件将在服务启动时自动下载"
-    fi
-    
     # 启动应用
     cd server
     node index.js
 else
     echo "❌ 未找到GSM3应用文件，正在启动传统Steam服务器管理..."
     echo
-    
+
     # 传统的Steam服务器管理菜单
     ARCH=$(uname -m)
     while true; do


### PR DESCRIPTION
## Summary

- publish only versioned Linux x64, Linux ARM64, and Windows archives
- resolve the latest stable release tag before constructing architecture-specific installer download URLs
- fall back from the GitHub Releases API to the direct or mirrored `releases/latest` redirect when API access is unavailable
- restrict release asset creation to tag push events to prevent duplicate uploads
- update PTY packaging documentation for the versioned-only release contract

## Release assets

Future releases will upload exactly these platform archives:

- `gsm3-management-panel-linux-x64-v<version>.tar.gz`
- `gsm3-management-panel-linux-arm64-v<version>.tar.gz`
- `gsm3-management-panel-windows-v<version>.zip`

## Validation

- `bash -n install-gsm3.sh`
- GitHub Actions YAML parse and versioned-only asset assertions
- direct GitHub API latest-tag resolution
- curl direct/mirrored release-page fallback resolution
- wget mirrored release-page fallback resolution
- current `v3.13.2` x64 and ARM64 versioned assets return HTTP 200 through both GitHub and ghfast
- `cd server && npx tsc --noEmit`
- `cd client && npx tsc --noEmit`
- `git diff --check`
- merge-tree check against current `upstream/main`

## Review result

The original mirrored API fallback currently returns HTTP 403. This PR now uses the mirrored GitHub release page redirect as the fallback instead. No blocking diagnostics or merge conflicts remain.